### PR TITLE
Map error.path items to strings

### DIFF
--- a/pytest_voluptuous/plugin.py
+++ b/pytest_voluptuous/plugin.py
@@ -12,9 +12,9 @@ def pytest_assertrepr_compare(op, left, right):
         else:
             source = right
         if isinstance(source.error, MultipleInvalid):
-            errors = ['- {}: {}'.format('.'.join(error.path), error) for error in source.error.errors]
+            errors = ['- {}: {}'.format('.'.join(map(str, error.path)), error) for error in source.error.errors]
         else:
-            errors = ['- {}: {}'.format('.'.join(source.error.path), source.error)]
+            errors = ['- {}: {}'.format('.'.join(map(str, source.error.path)), source.error)]
         return [
             'failed to validation error(s):'
         ] + errors


### PR DESCRIPTION
This is necessary as the path will contain integers when erroring on
a schema inside a list, which breaks the join with a TypeError.

A simple test-case
```
from voluptuous import Schema
from voluptuous import MultipleInvalid

x = Schema({'foo': [Schema({'id': int})]})

try:
    x({'foo': [{'id': 'bar'}]})
except MultipleInvalid as ex:
    print(ex.errors[0].path)
    print(".".join(ex.errors[0].path))
```
outputs:
```
voluptuous.error.MultipleInvalid: expected int for dictionary value @ data['foo'][0]['id']

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 10, in <module>
    print(".".join(ex.errors[0].path))
TypeError: sequence item 1: expected str instance, int found
```