### PR TITLE
Dev: Fix coverage measurement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ install:
 
 script:
   - tox
-  # Needed for coveralls (.coverage files in tox envs not available):
-  - inv develop
-  - inv test
 
 after_success:
   - coveralls

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+TBD
+---
+
+**Dev**:
+
+- `#8 <https://github.com/F-Secure/pytest-voluptuous/pull/8>`_:
+  Fix coverage measurement (lines that were executed before pytest-cov was loaded were not measured before).
+  Thanks `@bjoluc <https://github.com/bjoluc>`_!
+
 1.2.0 (2020-06-09)
 ------------------
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,5 +4,5 @@ invoke == 0.22.0
 requests == 2.20.0
 tox == 2.9.1
 pytest == 3.10.1
-pytest-cov == 2.5.1
+coverage == 4.5.4
 twine == 1.9.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,10 @@ max-line-length=120
 [tool:pytest]
 ;doctest_optionflags = IGNORE_EXCEPTION_DETAIL
 addopts = --doctest-modules --doctest-glob="*.rst" --ignore=setup.py
+
+[coverage:run]
+branch = true
+source = pytest_voluptuous
+
+[coverage:report]
+show_missing = 1

--- a/tasks.py
+++ b/tasks.py
@@ -32,7 +32,8 @@ def analyze(ctx):
 @task
 def test(ctx):
     """Run unit tests."""
-    ctx.run('pytest --cov pytest_voluptuous --cov-report term-missing')
+    ctx.run('coverage run --append -m pytest')
+    ctx.run('coverage report')
 
 
 @task


### PR DESCRIPTION
The coverage is not as bad as displayed :relaxed: Measuring plugin coverage with pytest-cov just does not report lines that are executed when pytest itself is initializing (discovered that when I built pytest-reraise). This PR replaces pytest-cov with the plain old `coverage run` command. Also, using `--append`, the coverage can be collected during the tox run.